### PR TITLE
Update notebooks to use pip

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,8 +1,3 @@
 #!/bin/sh
-wget -nv https://codeload.github.com/econ-ark/HARK/tar.gz/master
-mv master lib
-cd lib
-tar -xzf master
-rm master
 jupyter contrib nbextension install --user
 jupyter nbextension enable hide_input/main

--- a/notebooks/Chinese Growth.ipynb
+++ b/notebooks/Chinese Growth.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "source": [
+    "import sys\n",
+    "!{sys.executable} -m pip install econ-ark"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
    "outputs": [],
@@ -10,12 +19,7 @@
     "# The first step is to be able to bring things in from different directories\n",
     "import sys \n",
     "import os\n",
-    "# Get the path to HARK either from an env variable or use the default. Remove this\n",
-    "# once HARK is pip installable\n",
-    "HARK_PATH = os.path.abspath(os.path.join('..', os.environ.get('HARK_PATH', 'lib/HARK-master')))\n",
     "\n",
-    "sys.path.insert(0, os.path.join(HARK_PATH, 'ConsumptionSaving')) #Path to ConsumptionSaving folder\n",
-    "sys.path.insert(0, HARK_PATH)\n",
     "sys.path.insert(0, os.path.abspath('../lib'))\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -169,7 +173,7 @@
     }
    ],
    "source": [
-    "from ConsMarkovModel import MarkovConsumerType\n",
+    "from Demos.ConsumptionSaving.ConsMarkovModel import MarkovConsumerType\n",
     "ChinaExample = MarkovConsumerType(**init_China_parameters)"
    ]
   },
@@ -236,7 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from HARKutilities import approxUniform\n",
+    "from HARK.utilities import approxUniform\n",
     "\n",
     "bottomDiscFac = 0.9800\n",
     "topDiscFac    = 0.9934 \n",
@@ -267,8 +271,8 @@
    "outputs": [],
    "source": [
     "# First create the income distribution in the low-growth state, which we will not change\n",
-    "from ConsIndShockModel import constructLognormalIncomeProcessUnemployment\n",
-    "import ConsumerParameters as IncomeParams\n",
+    "from Demos.ConsumptionSaving.ConsIndShockModel import constructLognormalIncomeProcessUnemployment\n",
+    "import Demos.ConsumptionSaving.ConsumerParameters as IncomeParams\n",
     "\n",
     "LowGrowthIncomeDstn  = constructLognormalIncomeProcessUnemployment(IncomeParams)[0][0]\n",
     "\n",

--- a/notebooks/ConsIndShockModel.ipynb
+++ b/notebooks/ConsIndShockModel.ipynb
@@ -22,19 +22,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
+    "!{sys.executable} -m pip install econ-ark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import sys \n",
     "import os\n",
     "\n",
-    "# Get the path to HARK either from an env variable or use the default. Remove this\n",
-    "# once HARK is pip installable\n",
-    "HARK_PATH = os.path.abspath(os.path.join('..', os.environ.get('HARK_PATH', 'lib/HARK-master')))\n",
-    "\n",
-    "sys.path.insert(0, os.path.join(HARK_PATH, 'ConsumptionSaving')) #Path to ConsumptionSaving folder\n",
-    "sys.path.insert(0, HARK_PATH)\n",
-    "\n",
-    "from ConsIndShockModel import *\n",
-    "import ConsumerParameters as Params\n",
-    "from HARKutilities import plotFuncsDer, plotFuncs\n",
+    "from Demos.ConsumptionSaving.ConsIndShockModel import *\n",
+    "import Demos.ConsumptionSaving.ConsumerParameters as Params\n",
+    "from HARK.utilities import plotFuncsDer, plotFuncs\n",
     "from time import clock\n",
     "mystr = lambda number : \"{:.4f}\".format(number)"
    ]

--- a/notebooks/Non-Durables During Great Recession.ipynb
+++ b/notebooks/Non-Durables During Great Recession.ipynb
@@ -3,9 +3,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "!{sys.executable} -m pip install econ-ark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Hide this cell\n",
@@ -19,13 +27,8 @@
     "import sys \n",
     "import os\n",
     "\n",
-    "# Get the path to HARK either from an env variable or use the default. Remove this\n",
-    "# once HARK is pip installable\n",
-    "HARK_PATH = os.path.abspath(os.path.join('..', os.environ.get('HARK_PATH', 'lib/HARK-master')))\n",
-    "\n",
-    "sys.path.insert(0, os.path.join(HARK_PATH, 'ConsumptionSaving')) #Path to ConsumptionSaving folder\n",
-    "sys.path.insert(0, HARK_PATH)\n",
     "sys.path.insert(0, os.path.abspath('../lib'))\n",
+    "\n",
     "from util import log_progress\n",
     "\n",
     "import numpy as np\n",
@@ -63,7 +66,7 @@
     }
    ],
    "source": [
-    "from HARKutilities import approxUniform\n",
+    "from HARK.utilities import approxUniform\n",
     "\n",
     "# Bring in what we need from the cstwMPC parameters\n",
     "init_infinite = {\n",
@@ -105,7 +108,7 @@
     "# Import the HARK ConsumerType we want \n",
     "# Here, we bring in an agent making a consumption/savings decision every period, subject\n",
     "# to transitory and permanent income shocks.\n",
-    "from ConsIndShockModel import IndShockConsumerType\n",
+    "from Demos.ConsumptionSaving.ConsIndShockModel import IndShockConsumerType\n",
     "\n",
     "# Now initialize a baseline consumer type, using default parameters from infinite horizon cstwMPC\n",
     "BaselineType = IndShockConsumerType(**init_infinite)\n",
@@ -332,7 +335,7 @@
     "## Now, plot the functions we want\n",
     "\n",
     "# Import a useful plotting function from HARKutilities\n",
-    "from HARKutilities import plotFuncs\n",
+    "from HARK.utilities import plotFuncs\n",
     "\n",
     "ratio_min = 0.5 # minimum number to multiply income parameter by\n",
     "targetChangeInC = -6.32 # Source: FRED\n",


### PR DESCRIPTION
Use the pip-installable version of HARK[1] in the three notebooks, rather than the fetched version. Remove the fetch instructions from the build process.

[1] https://pypi.org/project/econ-ark/