### PR TITLE
Add Jupytext configuration metadata

### DIFF
--- a/notebooks/Alternative-Combos-Of-Parameter-Values.ipynb
+++ b/notebooks/Alternative-Combos-Of-Parameter-Values.ipynb
@@ -279,6 +279,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/ChangeLiqConstr.ipynb
+++ b/notebooks/ChangeLiqConstr.ipynb
@@ -119,6 +119,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/Chinese-Growth.ipynb
+++ b/notebooks/Chinese-Growth.ipynb
@@ -507,6 +507,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/ConsIndShockModel.ipynb
+++ b/notebooks/ConsIndShockModel.ipynb
@@ -247,6 +247,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/GenIncProcessModel.ipynb
+++ b/notebooks/GenIncProcessModel.ipynb
@@ -512,6 +512,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/Gentle-Intro-To-HARK.ipynb
+++ b/notebooks/Gentle-Intro-To-HARK.ipynb
@@ -506,6 +506,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/IncExpectationExample.ipynb
+++ b/notebooks/IncExpectationExample.ipynb
@@ -277,6 +277,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/IncExpectationExample_Roszypal-Schlafmann.ipynb
+++ b/notebooks/IncExpectationExample_Roszypal-Schlafmann.ipynb
@@ -907,6 +907,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs-Solutions.ipynb
+++ b/notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs-Solutions.ipynb
@@ -481,6 +481,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.ipynb
+++ b/notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.ipynb
@@ -602,6 +602,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/Nondurables-During-Great-Recession.ipynb
+++ b/notebooks/Nondurables-During-Great-Recession.ipynb
@@ -408,6 +408,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/notebooks/TractableBufferStockQuickDemo.ipynb
+++ b/notebooks/TractableBufferStockQuickDemo.ipynb
@@ -304,6 +304,10 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py",
+   "metadata_filter": {"cells": "collapsed"}
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
This pull request introduces [Jupytext](https://github.com/mwouts/jupytext/blob/master/README.md) per-notebook configuration added to each notebook's metadata.

The chosen configuration allows exporting to 'python' and 'notebook' formats, pairing 'python' and 'notebook' files, and also preserves the 'collapsed' directive for notebook cells.