### PR TITLE
Auto adds Zotero library config for cite2c

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,3 +2,9 @@
 jupyter contrib nbextension install --user
 jupyter nbextension enable codefolding/main
 python -m cite2c.install
+result=$(python <<EOF
+from notebook.services.config.manager import ConfigManager
+cm = ConfigManager()
+cm.update('cite2c', {'zotero':{"user_id": "5043554","username": "econ-ark","access_token": "XZpH9NsoAZmDMmjLKiy8xMXX"}})
+EOF
+)


### PR DESCRIPTION
This addition to the postBuild script automatically configures and authenticates Jupyter Notebook editor to the EconARK Zotero library when using the cite2c tool.