### PR TITLE
Correct the link to the borrowing constraint paper(s).

### DIFF
--- a/notebooks/ConsIndShockModel.ipynb
+++ b/notebooks/ConsIndShockModel.ipynb
@@ -13,13 +13,12 @@
    "metadata": {
     "code_folding": [
      0
-    ],
-    "collapsed": true
+    ]
    },
    "outputs": [],
    "source": [
     "# Initial imports and notebook setup, click arrow to show\n",
-    "import sys \n",
+    "import sys\n",
     "import os\n",
     "\n",
     "from HARK.ConsumptionSaving.ConsIndShockModel import *\n",
@@ -56,12 +55,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "PFexample = PerfForesightConsumerType(**Params.init_perfect_foresight)   \n",
+    "PFexample = PerfForesightConsumerType(**Params.init_perfect_foresight)\n",
     "PFexample.cycles = 0 # Make this type have an infinite horizon\n",
     "\n",
     "PFexample.solve()\n",
@@ -92,7 +89,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
@@ -114,7 +111,7 @@
     "\n",
     "# Compare the consumption functions for the perfect foresight and idiosyncratic\n",
     "# shock types.  Risky income cFunc asymptotically approaches perfect foresight cFunc.\n",
-    "print('Consumption functions for perfect foresight vs idiosyncratic shocks:')            \n",
+    "print('Consumption functions for perfect foresight vs idiosyncratic shocks:')\n",
     "plotFuncs([PFexample.cFunc[0],IndShockExample.cFunc[0]],IndShockExample.solution[0].mNrmMin,100)\n",
     "\n",
     "# Compare the value functions for the two types\n",
@@ -128,7 +125,7 @@
     "IndShockExample.track_vars = ['mNrmNow','cNrmNow','pLvlNow']\n",
     "IndShockExample.makeShockHistory() # This is optional, simulation will draw shocks on the fly if it isn't run.\n",
     "IndShockExample.initializeSim()\n",
-    "IndShockExample.simulate()\n"
+    "IndShockExample.simulate()"
    ]
   },
   {
@@ -179,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## \"Cyclical\" consumer type \n",
+    "## \"Cyclical\" consumer type\n",
     "Make and solve a \"cyclical\" consumer type who lives the same four quarters repeatedly.\n",
     "The consumer has income that greatly fluctuates throughout the year."
    ]
@@ -220,7 +217,9 @@
    "source": [
     "## Agent with a kinky interest rate (Rboro > RSave)\n",
     "\n",
-    "Models of this kind are analyzed in [A Theory of the Consumption Function, With and Without Liquidity Constraints](http://econ.jhu.edu/people/ccarroll/ATheoryv3.JEP)"
+    "Models of this kind are analyzed in [A Theory of the Consumption Function, With\n",
+    "and Without Liquidity Constraints](http://www.econ2.jhu.edu/people/ccarroll/ATheoryv3JEP.pdf)\n",
+    "and the [expanded edition](http://www.econ2.jhu.edu/people/ccarroll/ATheoryv3NBER.pdf)."
    ]
   },
   {
@@ -251,10 +250,20 @@
   }
  ],
  "metadata": {
+  "@webio": {
+   "lastCommId": "779f6c5616b04b58baaaa0f6c348270c",
+   "lastKernelId": "a944b08f-0ae0-4c26-883f-9fab53a82ac3"
+  },
   "jupytext": {
-   "formats": "ipynb,py",
+   "formats": "ipynb,py:percent",
    "metadata_filter": {
     "cells": "collapsed"
+   },
+   "text_representation": {
+    "extension": ".py",
+    "format_name": "percent",
+    "format_version": "1.1",
+    "jupytext_version": "0.8.3"
    }
   },
   "kernelspec": {
@@ -272,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/ConsIndShockModel.py
+++ b/notebooks/ConsIndShockModel.py
@@ -1,5 +1,8 @@
 # ---
 # jupyter:
+#   '@webio':
+#     lastCommId: 779f6c5616b04b58baaaa0f6c348270c
+#     lastKernelId: a944b08f-0ae0-4c26-883f-9fab53a82ac3
 #   jupytext:
 #     formats: ipynb,py:percent
 #     metadata_filter:
@@ -22,7 +25,7 @@
 #     name: python
 #     nbconvert_exporter: python
 #     pygments_lexer: ipython3
-#     version: 3.6.6
+#     version: 3.6.5
 # ---
 
 # %% [markdown]
@@ -30,7 +33,7 @@
 
 # %% {"code_folding": [0]}
 # Initial imports and notebook setup, click arrow to show
-import sys 
+import sys
 import os
 
 from HARK.ConsumptionSaving.ConsIndShockModel import *
@@ -56,7 +59,7 @@ mystr = lambda number : "{:.4f}".format(number)
 # Solve the model described in [PerfForesightCRRA](http://econ.jhu.edu/people/ccarroll/public/lecturenotes/consumption/PerfForesightCRRA)
 
 # %%
-PFexample = PerfForesightConsumerType(**Params.init_perfect_foresight)   
+PFexample = PerfForesightConsumerType(**Params.init_perfect_foresight)
 PFexample.cycles = 0 # Make this type have an infinite horizon
 
 PFexample.solve()
@@ -97,7 +100,7 @@ plotFuncsDer(IndShockExample.cFunc[0],IndShockExample.solution[0].mNrmMin,5)
 
 # Compare the consumption functions for the perfect foresight and idiosyncratic
 # shock types.  Risky income cFunc asymptotically approaches perfect foresight cFunc.
-print('Consumption functions for perfect foresight vs idiosyncratic shocks:')            
+print('Consumption functions for perfect foresight vs idiosyncratic shocks:')
 plotFuncs([PFexample.cFunc[0],IndShockExample.cFunc[0]],IndShockExample.solution[0].mNrmMin,100)
 
 # Compare the value functions for the two types
@@ -147,7 +150,7 @@ LifecycleExample.initializeSim()
 LifecycleExample.simulate()
 
 # %% [markdown]
-# ## "Cyclical" consumer type 
+# ## "Cyclical" consumer type
 # Make and solve a "cyclical" consumer type who lives the same four quarters repeatedly.
 # The consumer has income that greatly fluctuates throughout the year.
 
@@ -176,7 +179,9 @@ CyclicalExample.simulate()
 # %% [markdown]
 # ## Agent with a kinky interest rate (Rboro > RSave)
 #
-# Models of this kind are analyzed in [A Theory of the Consumption Function, With and Without Liquidity Constraints](http://econ.jhu.edu/people/ccarroll/ATheoryv3.JEP)
+# Models of this kind are analyzed in [A Theory of the Consumption Function, With
+# and Without Liquidity Constraints](http://www.econ2.jhu.edu/people/ccarroll/ATheoryv3JEP.pdf)
+# and the [expanded edition](http://www.econ2.jhu.edu/people/ccarroll/ATheoryv3NBER.pdf).
 
 # %%
 KinkyExample = KinkedRconsumerType(**Params.init_kinked_R)


### PR DESCRIPTION
The link to the paper on borrowing constraints was wrong, so I corrected it, and added a link for the xpanded version.

These are the relevant lines https://github.com/econ-ark/DemARK/compare/links?expand=1#diff-634b2d9f35a30a5111b51ff01155c455R220 the rest is just white space being stripped by my editor.
