### PR TITLE
Update requirements as numpy v1.14 will break with py3.7 

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,7 +1,7 @@
-matplotlib==2.1.2
-numpy==1.14.0
-ipywidgets==7.2.1
-scipy==1.0.0
+matplotlib
+numpy
+ipywidgets
+scipy
 jupyter
 cite2c
 econ-ark


### PR DESCRIPTION
and matplotlib and SciPy versions will require locally building wheels as they don't exist on pypi.

Breaks binder 