### PR TITLE
Add markdown metadata files for notebooks

### DIFF
--- a/notebooks/Alternative-Combos-Of-Parameter-Values.md
+++ b/notebooks/Alternative-Combos-Of-Parameter-Values.md
@@ -1,0 +1,22 @@
+---
+name: Alternative Combos Of Parameter Values
+tags:
+  - DemARK
+  - Demonstration
+  - Assignment
+  - Notebook
+abstract: "Alternative Combinations of Parameter Values"
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+date-released: 2018/09/12
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/Alternative-Combos-Of-Parameter-Values.ipynb
+dashboards:
+---
+
+Alternative Combinations of Parameter Values

--- a/notebooks/ChangeLiqConstr.md
+++ b/notebooks/ChangeLiqConstr.md
@@ -1,0 +1,21 @@
+---
+name: Change Liq Constr
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'What Happens To the Consumption Function When A Liquidity Constraint is Tightened?'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+date-released: 
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/ChangeLiqConstr.ipynb
+dashboards:
+---
+
+What Happens To the Consumption Function When A Liquidity Constraint is Tightened?

--- a/notebooks/Chinese-Growth.md
+++ b/notebooks/Chinese-Growth.md
@@ -1,0 +1,21 @@
+---
+name: Chinese Growth
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: "Do Precautionary Motives Explain China's High Saving Rate?"
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+date-released: 
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/Chinese-Growth.ipynb
+dashboards:
+---
+
+Do Precautionary Motives Explain China's High Saving Rate ?

--- a/notebooks/DCEGM-Upper-Envelope.md
+++ b/notebooks/DCEGM-Upper-Envelope.md
@@ -1,0 +1,22 @@
+---
+name: DCEGM-Upper-Envelope
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'DCEGM Upper Envelope'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+date-released: 
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/DCEGM-Upper-Envelope.ipynb
+dashboards:
+---
+
+DCEGM Upper Envelope
+"The endogenous grid method for discrete-continuous dynamic choice models with (or without) taste shocks"

--- a/notebooks/DiamondOLG.md
+++ b/notebooks/DiamondOLG.md
@@ -1,0 +1,21 @@
+---
+name: DiamondOLG
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'The Diamond OLG Model'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+date-released: 
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/DiamondOLG.ipynb
+dashboards:
+---
+
+The Diamond (1965) OLG Model

--- a/notebooks/FisherTwoPeriod.md
+++ b/notebooks/FisherTwoPeriod.md
@@ -1,0 +1,22 @@
+---
+name: FisherTwoPeriod
+tags:
+  - DemARK
+  - Demonstration
+  - Teaching
+  - Notebook
+abstract: 'The Fisher Two-Period Optimal Consumption Problem'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+date-released: 
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/FisherTwoPeriod.ipynb
+dashboards:
+---
+
+The Fisher Two-Period Optimal Consumption Problem

--- a/notebooks/Gentle-Intro-To-HARK-Buffer-Stock-Model.md
+++ b/notebooks/Gentle-Intro-To-HARK-Buffer-Stock-Model.md
@@ -1,0 +1,22 @@
+---
+name: Gentle-Intro-To-HARK-Buffer-Stock-Model
+tags:
+  - DemARK
+  - Demonstration
+  - Tutorial
+  - Teaching
+  - Notebook
+abstract: 'A Gentle Introduction to Buffer Stock Saving'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/Gentle-Intro-To-HARK-Buffer-Stock-Model.ipynb
+dashboards:
+---
+
+A Gentle Introduction to Buffer Stock Saving

--- a/notebooks/Gentle-Intro-To-HARK-PerfForesightCRRA.md
+++ b/notebooks/Gentle-Intro-To-HARK-PerfForesightCRRA.md
@@ -1,0 +1,21 @@
+---
+name: Gentle-Intro-To-HARK-PerfForesightCRRA
+tags:
+  - DemARK
+  - Demonstration
+  - Tutorial
+  - Notebook
+abstract: 'A Gentle Introduction to HARK In Perfect Foresight'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/Gentle-Intro-To-HARK-PerfForesightCRRA.ipynb
+dashboards:
+---
+
+A Gentle Introduction to HARK In Perfect Foresight

--- a/notebooks/IncExpectationExample.md
+++ b/notebooks/IncExpectationExample.md
@@ -1,0 +1,20 @@
+---
+name: IncExpectationExample
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'The Persistent Shock Model and Income Expectations'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/IncExpectationExample.ipynb
+dashboards:
+---
+
+The Persistent Shock Model and Income Expectations

--- a/notebooks/KeynesFriedmanModigliani.md
+++ b/notebooks/KeynesFriedmanModigliani.md
@@ -1,0 +1,21 @@
+---
+name: KeynesFriedmanModigliani
+tags:
+  - DemARK
+  - Demonstration
+  - Teaching
+  - Notebook
+abstract: 'Introduction: Keynes, Friedman, Modigliani'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/KeynesFriedmanModigliani.ipynb
+dashboards:
+---
+
+Introduction: Keynes, Friedman, Modigliani

--- a/notebooks/LifeCycleModelTheoryVsData.md
+++ b/notebooks/LifeCycleModelTheoryVsData.md
@@ -1,0 +1,21 @@
+---
+name: LifeCycleModelTheoryVsData
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'The Life Cycle Model: Theory vs Data'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/LifeCycleModelTheoryVsData.ipynb
+dashboards:
+---
+
+The Life Cycle Model: Theory vs Data
+

--- a/notebooks/MPC-Out-of-Credit-vs-MPC-Out-of-Income.md
+++ b/notebooks/MPC-Out-of-Credit-vs-MPC-Out-of-Income.md
@@ -1,0 +1,20 @@
+---
+name: MPC-Out-of-Credit-vs-MPC-Out-of-Income
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'The MPC out of Credit vs the MPC Out of Income'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/MPC-Out-of-Credit-vs-MPC-Out-of-Income.ipynb
+dashboards:
+---
+
+The MPC out of Credit vs the MPC Out of Income

--- a/notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.md
+++ b/notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.md
@@ -1,0 +1,20 @@
+---
+name: Micro-and-Macro-Implications-of-Very-Impatient-HHs
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'Micro- and Macroeconomic Implications of Very Impatient Households'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.ipynb
+dashboards:
+---
+
+Micro- and Macroeconomic Implications of Very Impatient Households

--- a/notebooks/Nondurables-During-Great-Recession.md
+++ b/notebooks/Nondurables-During-Great-Recession.md
@@ -1,0 +1,20 @@
+---
+name: Nondurables-During-Great-Recession
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'Spending on Nondurables During the Great Recession'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/Nondurables-During-Great-Recession.ipynb
+dashboards:
+---
+
+Spending on Nondurables During the Great Recession

--- a/notebooks/PerfForesightCRRA-Approximation.md
+++ b/notebooks/PerfForesightCRRA-Approximation.md
@@ -1,0 +1,21 @@
+---
+name: PerfForesightCRRA-Approximation
+tags:
+  - DemARK
+  - Demonstration
+  - Teaching
+  - Notebook
+abstract: 'Perfect Foresight CRRA Model - Approximation'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/PerfForesightCRRA-Approximation.ipynb
+dashboards:
+---
+
+Perfect Foresight CRRA Model - Approximation

--- a/notebooks/PerfForesightCRRA-SavingRate.md
+++ b/notebooks/PerfForesightCRRA-SavingRate.md
@@ -1,0 +1,21 @@
+---
+name: PerfForesightCRRA-SavingRate
+tags:
+  - DemARK
+  - Demonstration
+  - Teaching
+  - Notebook
+abstract: 'Perfect Foresight CRRA Model - Savings Rate'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/PerfForesightCRRA-SavingRate.ipynb
+dashboards:
+---
+
+Perfect Foresight CRRA Model - Savings Rate

--- a/notebooks/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al.md
+++ b/notebooks/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al.md
@@ -1,0 +1,23 @@
+---
+name: Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al
+tags:
+  - DemARK
+  - Demonstration
+  - Notebook
+abstract: 'Making Structural Estimates From Empirical Results'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+  -
+    family-names: White
+    given-names: "Matthew N."
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al.ipynb
+dashboards:
+---
+
+Making Structural Estimates From Empirical Results

--- a/notebooks/TractableBufferStock-Interactive.md
+++ b/notebooks/TractableBufferStock-Interactive.md
@@ -1,0 +1,21 @@
+---
+name: TractableBufferStock-Interactive
+tags:
+  - DemARK
+  - Demonstration
+  - Teaching
+  - Notebook
+abstract: 'The Tractable Buffer Stock Model'
+authors:
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+github_repo_url: https://github.com/econ-ark/DemARK
+notebooks:
+  - 
+    notebooks/TractableBufferStock-Interactive.ipynb
+dashboards:
+---
+
+The Tractable Buffer Stock Model


### PR DESCRIPTION
This PR simply adds a markdown file (previously hosted on the Econ-ARK website) next to each notebook file. These follow the new front-matter metadata format created by @llorracc .