### PR TITLE
Fix "alternative combos of parameters"

### DIFF
--- a/notebooks/Alternative-Combos-Of-Parameter-Values.ipynb
+++ b/notebooks/Alternative-Combos-Of-Parameter-Values.ipynb
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "code_folding": []
    },
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "code_folding": [
      0,
@@ -92,8 +92,8 @@
     "    \"TranShkCount\":5,  # Number of points in transitory income shock grid\n",
     "    \"UnempPrb\":0.07,  # Probability of unemployment while working\n",
     "    \"IncUnemp\":0.15,  # Unemployment benefit replacement rate\n",
-    "    \"UnempPrbRet\":None,\n",
-    "    \"IncUnempRet\":None,\n",
+    "    \"UnempPrbRet\":0.0,\n",
+    "    \"IncUnempRet\":0.0,\n",
     "    \"aXtraMin\":0.00001,  # Minimum end-of-period assets in grid\n",
     "    \"aXtraMax\":40,  # Maximum end-of-period assets in grid\n",
     "    \"aXtraCount\":32,  # Number of points in assets grid\n",
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,9 +140,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.82s/it]\n"
+     ]
+    }
+   ],
    "source": [
     "for ThisType in tqdm(MyTypes):\n",
     "    ThisType.solve()\n",
@@ -159,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,9 +253,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The 5.0th percentile of the MPC is 0.38302264790181284\n",
+      "The 10.0th percentile of the MPC is 0.4190098031734283\n",
+      "The 15.0th percentile of the MPC is 0.459847011605818\n",
+      "The 20.0th percentile of the MPC is 0.459847011605818\n",
+      "The 25.0th percentile of the MPC is 0.459847011605818\n",
+      "The 30.0th percentile of the MPC is 0.4979166414954169\n",
+      "The 35.0th percentile of the MPC is 0.4979166414954169\n",
+      "The 40.0th percentile of the MPC is 0.4979166414954169\n",
+      "The 44.99999999999999th percentile of the MPC is 0.5372418610399285\n",
+      "The 49.99999999999999th percentile of the MPC is 0.5372418610399285\n",
+      "The 54.99999999999999th percentile of the MPC is 0.5821887061768998\n",
+      "The 60.0th percentile of the MPC is 0.5821887061768998\n",
+      "The 65.0th percentile of the MPC is 0.5821887061768998\n",
+      "The 70.0th percentile of the MPC is 0.6345373126858334\n",
+      "The 75.0th percentile of the MPC is 0.6345373126858334\n",
+      "The 80.0th percentile of the MPC is 0.7267307307276025\n",
+      "The 85.0th percentile of the MPC is 0.7799255201452849\n",
+      "The 90.0th percentile of the MPC is 0.8208530902866044\n",
+      "The 95.0th percentile of the MPC is 0.8966083611183626\n"
+     ]
+    }
+   ],
    "source": [
     "# Write a function to tell us about the distribution of the MPC in this code block, then test it!\n",
     "# You will almost surely find it useful to use a for loop in this function.\n",
@@ -280,7 +314,7 @@
    "notebook_metadata_filter": "all"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -294,7 +328,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/notebooks/Alternative-Combos-Of-Parameter-Values.py
+++ b/notebooks/Alternative-Combos-Of-Parameter-Values.py
@@ -9,9 +9,9 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.10.2
+#       jupytext_version: 1.13.0
 #   kernelspec:
-#     display_name: Python 3
+#     display_name: Python 3 (ipykernel)
 #     language: python
 #     name: python3
 #   language_info:
@@ -23,7 +23,7 @@
 #     name: python
 #     nbconvert_exporter: python
 #     pygments_lexer: ipython3
-#     version: 3.8.5
+#     version: 3.8.8
 #   latex_envs:
 #     LaTeX_envs_menu_present: true
 #     autoclose: false
@@ -112,8 +112,8 @@ cstwMPC_calibrated_parameters = {
     "TranShkCount":5,  # Number of points in transitory income shock grid
     "UnempPrb":0.07,  # Probability of unemployment while working
     "IncUnemp":0.15,  # Unemployment benefit replacement rate
-    "UnempPrbRet":None,
-    "IncUnempRet":None,
+    "UnempPrbRet":0.0,
+    "IncUnempRet":0.0,
     "aXtraMin":0.00001,  # Minimum end-of-period assets in grid
     "aXtraMax":40,  # Maximum end-of-period assets in grid
     "aXtraCount":32,  # Number of points in assets grid


### PR DESCRIPTION
My last HARK pr (https://github.com/econ-ark/HARK/pull/1112) broke some notebooks.

It appears like "alternative-combos" is the last one. This PR fixes ("updates") it.