### PR TITLE
Use env.yml for binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,19 @@
+name: DemARK
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - matplotlib
+  - numpy
+  - ipywidgets
+  - seaborn
+  - scipy
+  - pandas
+  - pandas-datareader
+  - statsmodels
+  - linearmodels
+  - tqdm
+  - nbval
+  pip:
+    - cite2c
+    - git+https://github.com/econ-ark/hark@master


### PR DESCRIPTION
Let's start using conda envs to control python version and dependencies.

Why do we have [requirements_except_hark.txt](https://github.com/econ-ark/DemARK/blob/master/binder/requirements_except_hark.txt) file? I saw you added this file @llorracc