### PR TITLE
Use micromamba in CI and drop py3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
             pytest
       - name: Test with nbval
         run: |
-          pytest --nbval-lax --nbval-cell-timeout=12000 --ignore=notebooks/Chinese-Growth.ipynb  notebooks/
+          python -m pytest --nbval-lax --nbval-cell-timeout=12000 --ignore=notebooks/Chinese-Growth.ipynb  notebooks/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,6 @@ jobs:
           extra-specs: |
             pytest
       - name: Test with nbval
+        shell: bash -l {0}
         run: |
           python -m pytest --nbval-lax --nbval-cell-timeout=12000 --ignore=notebooks/Chinese-Growth.ipynb  notebooks/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup mamba environment to run notebooks
         uses: mamba-org/provision-with-micromamba@main
         with:
-          environment-file: binder/environment.yaml
+          environment-file: binder/environment.yml
           extra-specs: |
             pytest
       - name: Test with nbval

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,17 @@ jobs:
       max-parallel: 12
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+
+      - name: Setup mamba environment to run notebooks
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r binder/requirements.txt
+          environment-file: binder/environment.yaml
+          extra-specs: |
+            pytest
       - name: Test with nbval
         run: |
-          pip install pytest
           pytest --nbval-lax --nbval-cell-timeout=12000 --ignore=notebooks/Chinese-Growth.ipynb  notebooks/


### PR DESCRIPTION
Testing out a new action for running our CI for DemARKs.