### PR TITLE
Fixed typo in Fisher2period notebook

### DIFF
--- a/notebooks/FisherTwoPeriod.ipynb
+++ b/notebooks/FisherTwoPeriod.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,24 +203,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a48d7d6ea344437ab9f8613448b9ce81",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=50.0, description='$Y_1$', readout_format='4f'), FloatSlider(value=50.…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make the widget\n",
     "interact(\n",
@@ -243,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +275,6 @@
     "    plt.figure(figsize=(8, 8))\n",
     "    plt.xlabel(\"Period 1 Consumption $C_1$\")\n",
     "    plt.ylabel(\"Period 2 Consumption $C_2$\")\n",
-    "    plt.title(\" All the income is earned in first period\")\n",
     "    plt.ylim([C_2_Min, C_2_Max])\n",
     "    plt.xlim([C_1_Min, C_1_Max])\n",
     "\n",
@@ -433,22 +417,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "84a3aeca318744a5bfaa8c6c51973f34",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=100.0, description='$Y_1$', readout_format='.1f'), FloatSlider(value=0…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make the widget\n",
     "\n",
@@ -473,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,24 +636,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f8eda952a73142f4bd953a090632acdb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=100.0, description='$Y_2$', readout_format='.1f'), FloatSlider(value=2…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make the widget\n",
     "\n",
@@ -711,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -780,24 +734,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "43ec2bc0db1747b690eebb8ca5065a5e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=10.0, description='$M_1$', max=10.0, min=0.1, readout_format='4f'), Fl…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We now define the controls that will receive and transmit the\n",
     "# user's input.\n",

--- a/notebooks/FisherTwoPeriod.ipynb
+++ b/notebooks/FisherTwoPeriod.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,6 +89,7 @@
     "    # Set interest rate and bank balances from input.\n",
     "    PFexample.Rfree = [R]\n",
     "    PFexample.aNrmInitMean = B_1\n",
+    "    \n",
     "\n",
     "    # Solve the model: this generates the optimal consumption function.\n",
     "\n",
@@ -136,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,13 +203,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3c659c35229143cf8b7121f521ca20b3",
+       "model_id": "a48d7d6ea344437ab9f8613448b9ce81",
        "version_major": 2,
        "version_minor": 0
       },
@@ -242,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,6 +290,7 @@
     "    plt.figure(figsize=(8, 8))\n",
     "    plt.xlabel(\"Period 1 Consumption $C_1$\")\n",
     "    plt.ylabel(\"Period 2 Consumption $C_2$\")\n",
+    "    plt.title(\" All the income is earned in first period\")\n",
     "    plt.ylim([C_2_Min, C_2_Max])\n",
     "    plt.xlim([C_1_Min, C_1_Max])\n",
     "\n",
@@ -345,7 +347,7 @@
     "        \"go\",\n",
     "        label=\"B: Income effect AB \\n     Substitution effect BC \",\n",
     "    )\n",
-    "    plt.plot(C_1_opt_RHi, C_2_opt_RHi, \"mo\", label=\"C: Optimal Consumption R High\")\n",
+    "    plt.plot(C_1_opt_RHi, C_2_opt_RHi, \"mo\", label=\"C: Optimal Consumption R High \")\n",
     "\n",
     "    plt.legend()\n",
     "    plt.show()\n",
@@ -355,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,13 +431,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d013e0b36e09487eac4653c71214d33b",
+       "model_id": "84a3aeca318744a5bfaa8c6c51973f34",
        "version_major": 2,
        "version_minor": 0
       },
@@ -671,7 +673,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e76188b5c784068a13ced0dc3467530",
+       "model_id": "f8eda952a73142f4bd953a090632acdb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -709,7 +711,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,11 +725,11 @@
     "\n",
     "    PFexample.cycles = 1  # let the agent live the cycle of periods just once\n",
     "    PFexample.T_cycle = 1  # One single non-terminal period\n",
-    "    PFexample.PermGroFac = [0]  # No income in the second period\n",
+    "    PFexample.PermGroFac = [1.0]  # No income in the second period\n",
     "    PFexample.LivPrb = [1.0]  # No chance of dying before the second period\n",
     "\n",
     "    # Set interest rate and bank balances from input.\n",
-    "    PFexample.Rfree = R\n",
+    "    PFexample.Rfree = [R]\n",
     "    PFexample.CRRA = CRRA\n",
     "    PFexample.DiscFac = beta\n",
     "\n",
@@ -778,13 +780,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "959877bcec984758b94db65e8dcfe345",
+       "model_id": "43ec2bc0db1747b690eebb8ca5065a5e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -878,13 +880,6 @@
     "    C_2_Max=C_2_Max_widget,\n",
     ");"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -893,7 +888,7 @@
    "notebook_metadata_filter": "all"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "DemARK",
    "language": "python",
    "name": "python3"
   },
@@ -907,7 +902,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.10.18"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
corrects two typos in FisherTwoPeriod.ipynb. In the code generating the fourth plot, the PermGroFac was mistakenly set to [0.0] (should be [1.0]), and the value for R was incorrectly specified (should be [R]). These changes ensure that the plot accurately reflects the intended parameter values, and does not throw the error- "Those parameters violate the solution"